### PR TITLE
Fix LSDB/NestedFrame sorting in score-density selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,12 @@ dev = [
   "asv[virtualenv]==0.6.6",
   "jupyter",
   "nbconvert>=7.16.6,<8",
-  "mypy==2.1.0",
+  "mypy==1.19.1",
   "pre-commit",
   "pytest",
   "pytest-cov",
   "ruff",
+  "setuptools>=83.0.0",
 ]
 docs = [
   "sphinx>=7.2,<10",
@@ -74,7 +75,7 @@ docs = [
 ]
 
 [build-system]
-requires = ["setuptools>=62"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/src/hipscatalog_gen/selection/common.py
+++ b/src/hipscatalog_gen/selection/common.py
@@ -20,6 +20,24 @@ def _as_plain_pandas_frame(pdf: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(pdf)
 
 
+def _sort_by_plain_keys(pdf: pd.DataFrame, sort_cols: list[str], ascending: list[bool]) -> pd.DataFrame:
+    """Sort using a plain helper frame with only key columns, then select rows by position."""
+    if pdf.empty:
+        return pdf
+
+    key_df = pd.DataFrame(index=pd.RangeIndex(len(pdf)))
+    for col in sort_cols:
+        values = pd.Series(pdf[col].to_numpy(), index=key_df.index)
+        numeric = pd.to_numeric(values, errors="coerce")
+        if numeric.notna().any() or values.isna().all():
+            key_df[col] = numeric
+        else:
+            key_df[col] = values.astype("string")
+
+    order = key_df.sort_values(sort_cols, ascending=ascending, kind="mergesort").index.to_numpy()
+    return pdf.iloc[order]
+
+
 def targets_per_tile(counts_depth: np.ndarray, depth_total: int, bias: float) -> Dict[int, int]:
     """Distribute depth_total across active tiles with optional density bias."""
     if depth_total <= 0:
@@ -95,7 +113,7 @@ def reduce_topk_by_group_dask(
         if dec_col in group.columns:
             sort_cols.append(dec_col)
             ascending.append(True)
-        group_sorted = group.sort_values(sort_cols, ascending=ascending, kind="mergesort")
+        group_sorted = _sort_by_plain_keys(group, sort_cols, ascending)
         return group_sorted.head(k)
 
     def _local_topk_partition(pdf: pd.DataFrame) -> pd.DataFrame:
@@ -120,7 +138,7 @@ def reduce_topk_by_group_dask(
             sort_cols.append(dec_col)
             ascending.append(True)
 
-        pdf_sorted = pdf.sort_values(sort_cols, ascending=ascending, kind="mergesort")
+        pdf_sorted = _sort_by_plain_keys(pdf, sort_cols, ascending)
         rank_in_group = pdf_sorted.groupby(group_col, sort=False).cumcount()
         k_by_row = pdf_sorted[group_col].map(k_map).fillna(0).astype("int64")
         keep_mask = rank_in_group.to_numpy() < k_by_row.to_numpy()

--- a/src/hipscatalog_gen/selection/common.py
+++ b/src/hipscatalog_gen/selection/common.py
@@ -13,6 +13,13 @@ from ..utils import _get_dask_base, _get_meta_df
 __all__ = ["targets_per_tile", "reduce_topk_by_group_dask", "add_ipix_column"]
 
 
+def _as_plain_pandas_frame(pdf: pd.DataFrame) -> pd.DataFrame:
+    """Return a plain pandas DataFrame, avoiding backend sort/groupby overrides."""
+    if type(pdf) is pd.DataFrame:
+        return pdf
+    return pd.DataFrame(pdf)
+
+
 def targets_per_tile(counts_depth: np.ndarray, depth_total: int, bias: float) -> Dict[int, int]:
     """Distribute depth_total across active tiles with optional density bias."""
     if depth_total <= 0:
@@ -70,6 +77,7 @@ def reduce_topk_by_group_dask(
 
     def _take_topk(group: pd.DataFrame) -> pd.DataFrame:
         """Select the top-k rows for a single group."""
+        group = _as_plain_pandas_frame(group)
         if group.empty:
             return group
         g_id = int(group[group_col].iloc[0])
@@ -92,6 +100,7 @@ def reduce_topk_by_group_dask(
 
     def _local_topk_partition(pdf: pd.DataFrame) -> pd.DataFrame:
         """Exact local pruning: keep only per-group top-k within this partition."""
+        pdf = _as_plain_pandas_frame(pdf)
         if pdf.empty:
             return pdf.iloc[0:0]
 

--- a/src/hipscatalog_gen/selection/slicing.py
+++ b/src/hipscatalog_gen/selection/slicing.py
@@ -20,7 +20,7 @@ import pandas as pd
 from ..io.output import build_header_line_from_keep, finalize_write_tiles
 from ..pipeline.common import write_tiles_with_allsky
 from ..utils import _fmt_dur, _get_meta_df, _log_depth_stats
-from .common import add_ipix_column
+from .common import _sort_by_plain_keys, add_ipix_column
 from .levels import assign_level_edges
 from .score import compute_score_histogram_ddf
 
@@ -88,10 +88,10 @@ def _merge_files_to_parquet(
     """Merge many parquet fragments into one sorted parquet file."""
     merged = pd.concat((pd.read_parquet(fp) for fp in input_files), ignore_index=True)
     if len(merged) > 0:
-        merged = merged.sort_values(
+        merged = _sort_by_plain_keys(
+            merged,
             ["__ipix__", *sort_cols],
-            ascending=[True, *ascending],
-            kind="mergesort",
+            [True, *ascending],
         )
     output_file.parent.mkdir(parents=True, exist_ok=True)
     merged.to_parquet(output_file, index=False)
@@ -471,7 +471,7 @@ def _stream_write_depth_without_allsky(
 
         local_sort_cols = ["__bucket__", "__ipix__", *sort_cols]
         local_ascending = [True, True, *ascending]
-        pdf_sorted = pdf.sort_values(local_sort_cols, ascending=local_ascending, kind="mergesort")
+        pdf_sorted = _sort_by_plain_keys(pdf, local_sort_cols, local_ascending)
 
         n_frag = 0
         for bid, grp in pdf_sorted.groupby("__bucket__", sort=True):
@@ -717,7 +717,7 @@ def select_by_value_slices(
                 if dec_col in selected_pdf.columns:
                     sort_cols.append(dec_col)
                     ascending.append(True)
-                selected_pdf = selected_pdf.sort_values(sort_cols, ascending=ascending, kind="mergesort")
+                selected_pdf = _sort_by_plain_keys(selected_pdf, sort_cols, ascending)
 
                 written_per_ipix, _ = write_tiles_with_allsky(
                     out_dir=out_dir,

--- a/tests/hipscatalog_gen/selection/test_selection_module.py
+++ b/tests/hipscatalog_gen/selection/test_selection_module.py
@@ -666,6 +666,31 @@ def test_reduce_topk_by_group_dask_handles_empty_and_missing(monkeypatch):
     )
 
 
+def test_reduce_topk_by_group_dask_plain_pandas_conversion():
+    """Top-k helpers avoid DataFrame subclass sort_values overrides."""
+
+    class BrokenSortFrame(pd.DataFrame):
+        @property
+        def _constructor(self):
+            return BrokenSortFrame
+
+        def sort_values(self, *args, **kwargs):
+            raise ValueError("backend sort_values should not be used")
+
+    broken = BrokenSortFrame(
+        {
+            "group": [1, 1, 2],
+            "score": [2.0, 1.0, 3.0],
+            "RA": [0.2, 0.1, 0.3],
+            "DEC": [0.0, 0.0, 0.0],
+        }
+    )
+
+    plain = selection_common._as_plain_pandas_frame(broken)
+    assert type(plain) is pd.DataFrame
+    assert plain.sort_values(["group", "score"]) is not None
+
+
 def test_add_ipix_column_handles_empty_and_nonempty():
     """add_ipix_column returns int64 __ipix__ and tolerates empty frames."""
     pdf = pd.DataFrame({"RA": [0.0, 90.0], "DEC": [0.0, 0.0]})

--- a/tests/hipscatalog_gen/selection/test_selection_module.py
+++ b/tests/hipscatalog_gen/selection/test_selection_module.py
@@ -688,7 +688,8 @@ def test_reduce_topk_by_group_dask_plain_pandas_conversion():
 
     plain = selection_common._as_plain_pandas_frame(broken)
     assert type(plain) is pd.DataFrame
-    assert plain.sort_values(["group", "score"]) is not None
+    sorted_plain = selection_common._sort_by_plain_keys(plain, ["group", "score"], [True, True])
+    assert sorted_plain["score"].tolist() == [1.0, 2.0, 3.0]
 
 
 def test_add_ipix_column_handles_empty_and_nonempty():


### PR DESCRIPTION
## Summary

This PR fixes failures when running `score_density_hybrid` on HATS catalogs opened through newer `lsdb/hats` versions, where partitions may arrive as `nested_pandas.NestedFrame`.

The previous implementation called `sort_values` directly on LSDB/NestedFrame-backed partitions during:

- stage-1 per-tile top-k selection
- stage-2 streamed score-slice writes for depths 5+
- parquet fragment merge/fallback ordering

With some catalogs, pandas/nested-pandas raises:

```text
ValueError: Categorical categories must be unique
```

To avoid backend-specific `sort_values` behavior, sorting is now performed through a plain pandas helper frame containing only the ordering keys, then applied back to the original rows by position.

## Changes

- Add helper sorting utilities for LSDB/NestedFrame-safe ordering.
- Replace direct `sort_values` calls in score-density top-k selection.
- Apply the same safe sorting path to streamed score-slice writes.
- Add unit coverage for DataFrame subclass sorting behavior.